### PR TITLE
Refuse to process if originalWidth or originalHeight are NaN

### DIFF
--- a/src/Textfit.js
+++ b/src/Textfit.js
@@ -100,12 +100,12 @@ export default createClass({
         const originalWidth = innerWidth(el);
         const originalHeight = innerHeight(el);
 
-        if (originalHeight <= 0) {
+        if (originalHeight <= 0 || isNaN(originalHeight)) {
             console.warn('Can not process element without height. Make sure the element is displayed and has a static height.');
             return;
         }
 
-        if (originalWidth <= 0) {
+        if (originalWidth <= 0 || isNaN(originalWidth)) {
             console.warn('Can not process element without width. Make sure the element is displayed and has a static width.');
             return;
         }


### PR DESCRIPTION
These values can be NaN if the element isn't yet added to the DOM or `window.getComputedStyle` is returning `""` for some other reason. When that happens, `react-textfit` gets stuck in an infinite loop.
