### PR TITLE
No longer passing remaining props to rendered div

### DIFF
--- a/src/Textfit.js
+++ b/src/Textfit.js
@@ -213,7 +213,7 @@ export default createClass({
         if (mode === 'single') wrapperStyle.whiteSpace = 'nowrap';
 
         return (
-            <div style={finalStyle} {...props}>
+            <div style={finalStyle}>
                 <span ref="wrapper" style={wrapperStyle}>
                     {text && typeof children === 'function'
                         ? ready


### PR DESCRIPTION
Regarding issue #6 . React v15 gives a warning about unknown props passed to `<div>` tag. There
does not seem to be a reason to pass the props into the div, but correct me if I'm wrong. Removed the props from the div.