### PR TITLE
Fix react15 warning concerning unknown props

### DIFF
--- a/src/Textfit.js
+++ b/src/Textfit.js
@@ -200,7 +200,7 @@ export default createClass({
     },
 
     render() {
-        const { children, text, style, min, max, mode, ...props } = this.props;
+        const { children, text, style, min, max, mode, forceWidth, forceSingleModeWidth, perfectFit, throttle, autoResize, onReady, ...props } = this.props;
         const { fontSize, ready } = this.state;
         const finalStyle = {
             ...style,


### PR DESCRIPTION
Due to react15 being strict in nature it does not allow unknown props to be supplied to html elements and throws the following warning.


`Unknown props 'forceWidth', 'forceSingleModeWidth', 'perfectFit', 'throttle', 'autoResize', 'onReady' on <div> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop`