### PR TITLE
use process library instead of relying on Node's process object

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "url": "https://github.com/malte-wessel/react-textfit.git"
   },
   "keywords": [
-      "textfit",
-      "fittext",
-      "text",
-      "react",
-      "react-component"
+    "textfit",
+    "fittext",
+    "text",
+    "react",
+    "react-component"
   ],
   "author": "Malte Wessel",
   "license": "MIT",
@@ -51,5 +51,7 @@
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "process": "^0.11.9"
+  }
 }

--- a/src/utils/series.js
+++ b/src/utils/series.js
@@ -8,6 +8,9 @@
  * @params {Array} tasks An array containing functions to run, each function is passed a callback(err, result) which it must call on completion with an error err (which can be null) and an optional result value.
  * @params {Function} callback(err, results) - An optional callback to run once all the functions have completed. This function gets a results array containing all the result arguments passed to the task callbacks.
  */
+
+import process from 'process';
+
 export default function series(tasks, cb) {
     const results = [];
     let current = 0;


### PR DESCRIPTION
This fixes a bug that occurs in environments where `process` is not defined (e.g. the browser).