### PR TITLE
Add 'array' as an accepted PropType

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ react-textfit
 * fit **headlines and paragraphs** into any element
 * **fast:** uses binary search for efficiently find the correct fit
 * **100%** react-goodness
-* works with **any style** configuration (line-height, padding, ...)
+* works with **any style** configuration (line-height, padding, ...) and **JSX text formatting** (bold, italic, ...)
 * **[check out the demo](http://malte-wessel.github.io/react-textfit/)**
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ react-textfit
 * fit **headlines and paragraphs** into any element
 * **fast:** uses binary search for efficiently find the correct fit
 * **100%** react-goodness
-* works with **any style** configuration (line-height, padding, ...) and **JSX text formatting** (bold, italic, ...)
+* works with **any style** configuration (line-height, padding, ...)
 * **[check out the demo](http://malte-wessel.github.io/react-textfit/)**
 
 ## Table of Contents
@@ -69,7 +69,7 @@ class App extends Component {
   render() {
     return (
       <Textfit mode="multi">
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        Lorem <strong>ipsum</strong> dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </Textfit>
     );
   }

--- a/examples/simple/components/App.js
+++ b/examples/simple/components/App.js
@@ -76,7 +76,7 @@ export default class App extends React.Component {
                     </div>
                     <div className="column-25">
                         <Textfit style={inlineStyle}>
-                            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+                            <strong>Lorem ipsum dolor sit amet</strong>, consetetur sadipscing elitr, <em>sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat</em>, sed diam voluptua. <b>At vero eos et accusam et justo duo dolores et ea rebum</b>. <br /> Stet clita kasd gubergren, <del>no sea takimata sanctus</del> est Lorem ipsum dolor sit amet. <mark>Lorem ipsum dolor sit amet</mark>, consetetur sadipscing elitr, <small>sed diam nonumy eirmod tempor invidunt ut</small> labore et dolore magna aliquyam erat, sed diam voluptua.
                         </Textfit>
                     </div>
                 </div>

--- a/examples/simple/components/App.js
+++ b/examples/simple/components/App.js
@@ -76,7 +76,7 @@ export default class App extends React.Component {
                     </div>
                     <div className="column-25">
                         <Textfit style={inlineStyle}>
-                            <strong>Lorem ipsum dolor sit amet</strong>, consetetur sadipscing elitr, <em>sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat</em>, sed diam voluptua. <b>At vero eos et accusam et justo duo dolores et ea rebum</b>. <br /> Stet clita kasd gubergren, <del>no sea takimata sanctus</del> est Lorem ipsum dolor sit amet. <mark>Lorem ipsum dolor sit amet</mark>, consetetur sadipscing elitr, <small>sed diam nonumy eirmod tempor invidunt ut</small> labore et dolore magna aliquyam erat, sed diam voluptua.
+                            <strong>Lorem ipsum dolor sit amet</strong>, consetetur sadipscing elitr, <em>sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat</em>, sed diam voluptua. <b>At vero eos et accusam et justo duo dolores et ea rebum</b>. <br /> Stet clita kasd gubergren, <del>no sea takimata sanctus</del> est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, <small>sed diam nonumy eirmod tempor invidunt ut</small> labore et dolore magna aliquyam erat, sed diam voluptua.
                         </Textfit>
                     </div>
                 </div>

--- a/src/Textfit.js
+++ b/src/Textfit.js
@@ -21,10 +21,7 @@ function noop() {}
 
 export default class TextFit extends React.Component {
     static propTypes = {
-        children: PropTypes.oneOfType([
-            PropTypes.string,
-            PropTypes.func
-        ]),
+        children: PropTypes.node,
         text: PropTypes.string,
         min: PropTypes.number,
         max: PropTypes.number,


### PR DESCRIPTION
It would be useful to have JSX arrays accepted as Textfit child.

For example:

`[
  <strong>Hello</strong>,
  <em> world</em>,
  "!",
  <br/>
]`

It _is_ actually working but it throws the error: 

`Warning: Failed prop type: Invalid prop 'children' supplied to 'Textfit'.`
