### PR TITLE
Return the clientWidth or clientHeight if getComputedStyle() returns null

### DIFF
--- a/src/utils/innerSize.js
+++ b/src/utils/innerSize.js
@@ -1,6 +1,7 @@
 // Calculate height without padding.
 export function innerHeight(el) {
     const style = window.getComputedStyle(el, null);
+    if (!style) return el.clientHeight;
     return el.clientHeight -
         parseInt(style.getPropertyValue('padding-top'), 10) -
         parseInt(style.getPropertyValue('padding-bottom'), 10);
@@ -9,6 +10,7 @@ export function innerHeight(el) {
 // Calculate width without padding.
 export function innerWidth(el) {
     const style = window.getComputedStyle(el, null);
+    if (!style) return el.clientWidth;
     return el.clientWidth -
         parseInt(style.getPropertyValue('padding-left'), 10) -
         parseInt(style.getPropertyValue('padding-right'), 10);


### PR DESCRIPTION
From using this library, we've hit a fairly edge case in Firefox where attempting to call `window.getComputedStyle()` inside of an iframe which is currently hidden consistently returns `null`. 

You can see the issue logged with Mozilla here: https://bugzilla.mozilla.org/show_bug.cgi?id=548397

Returning the `clientHeight` or `clientWidth` fixes my use case in Firefox without adversely affecting any other browser that I've tested in (IE11+, latest Safari, Chrome). 