### PR TITLE
move line of code out of deprecated (renamed to UNSAFE_) componentWillMount for React 16.9

### DIFF
--- a/src/Textfit.js
+++ b/src/Textfit.js
@@ -55,11 +55,8 @@ export default class TextFit extends React.Component {
         ready: false
     }
 
-    componentWillMount() {
-        this.handleWindowResize = throttle(this.handleWindowResize, this.props.throttle);
-    }
-
     componentDidMount() {
+        this.handleWindowResize = throttle(this.handleWindowResize, this.props.throttle);
         const { autoResize } = this.props;
         if (autoResize) {
             window.addEventListener('resize', this.handleWindowResize);


### PR DESCRIPTION
I moved this.handleWindowResize = throttle... from componentWillMount to componentDidMount as componentWillMount has been renamed and is not recommended in React 16.9.