### PR TITLE
Remove ComponentWillMount to constructor

### DIFF
--- a/src/Textfit.js
+++ b/src/Textfit.js
@@ -48,15 +48,13 @@ export default class TextFit extends React.Component {
         if ('perfectFit' in props) {
             console.warn('TextFit property perfectFit has been removed.');
         }
+        this.handleWindowResize = throttle(this.handleWindowResize, this.props.throttle);
+
     }
 
     state = {
         fontSize: null,
         ready: false
-    }
-
-    componentWillMount() {
-        this.handleWindowResize = throttle(this.handleWindowResize, this.props.throttle);
     }
 
     componentDidMount() {


### PR DESCRIPTION
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details