### PR TITLE
Fix stepCallback logic

### DIFF
--- a/src/Textfit.js
+++ b/src/Textfit.js
@@ -149,7 +149,7 @@ export default class TextFit extends React.Component {
                 low = min;
                 high = mid;
                 return whilst(
-                    () => low < high,
+                    () => low <= high,
                     whilstCallback => {
                         if (shouldCancelProcess()) return whilstCallback(true);
                         mid = parseInt((low + high) / 2, 10);


### PR DESCRIPTION
Hi, 

thank you for this nice library. There is a small bug, though, and I am surprised, no one did complain, yet. 

Problem is, that if you type a long word, the calculated text size is too large. For example, if you enter 
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
in the textarea on the example page, the text goes out of bounds.

Change is small, short explanation:

Let's say fontSize 10 is the correct result, and the loop get's to the situation that low is 10 and high is 11. mid is set to 10, testSecondary() returns true, so low is set to 11. 
With the current code, the loop is complete and the chosen fontSize is 11.
With the change, there would be another loop call, mid is set to 11, testSecondary() returns false and high is set to 10, which would return the correct fontSize.
